### PR TITLE
Remove case sensitivity of contract addresses

### DIFF
--- a/lib/core/event-fetcher.js
+++ b/lib/core/event-fetcher.js
@@ -29,12 +29,14 @@ class EventFetcher {
   }
 
   _parse(logs) {
-    return logs.map(log => parseLog(log, this._contracts.find(c => c.address === log.address).abi));
+    return logs.map(
+      log => parseLog(log, this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase()).abi)
+    );
   }
 
   _filter(logs) {
     return logs.filter(log => {
-      const contract = this._contracts.find(c => c.address === log.address);
+      const contract = this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase());
 
       return contract.events ? contract.events.includes(log.event) : true;
     });
@@ -47,7 +49,7 @@ class EventFetcher {
     return logs.map(log => {
       const transactionHash = log.transactionHash;
       const transaction = blocks[log.blockHash].transactions.find(e => e.hash === transactionHash);
-      const contract = this._contracts.find(c => c.address === log.address);
+      const contract = this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase());
 
       return {
         name: log.event,


### PR DESCRIPTION
Store contract addresses in lower case and use toLowerCase when comparing to prevent an error when an address doesn't match.