### PR TITLE
fix: Skip logs that the ABI cannot decode.

### DIFF
--- a/lib/core/event-fetcher.js
+++ b/lib/core/event-fetcher.js
@@ -34,7 +34,9 @@ class EventFetcher {
           try {
             let log = parseLog(log, this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase()).abi)
             return log
-          } catch (e) {}
+          } catch (e) {
+            console.warn(`Unable to decode event: ${JSON.stringify(log)}`)
+          }
         }
     ).filter(log => typeof log !== 'undefined')
   }

--- a/lib/core/event-fetcher.js
+++ b/lib/core/event-fetcher.js
@@ -30,8 +30,13 @@ class EventFetcher {
 
   _parse(logs) {
     return logs.map(
-      log => parseLog(log, this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase()).abi)
-    );
+        log => {
+          try {
+            let log = parseLog(log, this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase()).abi)
+            return log
+          } catch (e) {}
+        }
+    ).filter(log => typeof log !== 'undefined')
   }
 
   _filter(logs) {

--- a/lib/core/event-fetcher.js
+++ b/lib/core/event-fetcher.js
@@ -32,8 +32,8 @@ class EventFetcher {
     return logs.map(
         log => {
           try {
-            let log = parseLog(log, this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase()).abi)
-            return log
+            let parsed = parseLog(log, this._contracts.find(c => c.address.toLowerCase() === log.address.toLowerCase()).abi)
+            return parsed
           } catch (e) {
             console.warn(`Unable to decode event: ${JSON.stringify(log)}`)
           }


### PR DESCRIPTION
If EthereumEvents fetches a block that has events in it that it cannot decode it will fail out.  Basically, parseLog can fail if you have an incomplete ABI.  There are reasons for not having a complete ABI.

https://github.com/AleG94/ethereum-events/issues/4